### PR TITLE
resolves #22: Fixes spec to match instructions

### DIFF
--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -39,7 +39,7 @@ end
 
 describe "post" do
   it "has a post_status field" do
-    @post = Post.create(title: "My Post", description: "My post desc", post_status: true)
-    expect(@post.post_status).to eq(true)
+    @post = Post.create(title: "My Post", description: "My post desc", post_status: "true")
+    expect(@post.post_status).to eq("true")
   end
 end

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -39,7 +39,7 @@ end
 
 describe "post" do
   it "has a post_status field" do
-    @post = Post.create(title: "My Post", description: "My post desc", post_status: "true")
-    expect(@post.post_status).to eq("true")
+    @post = Post.create(title: "My Post", description: "My post desc", post_status: "draft")
+    expect(@post.post_status).to eq("draft")
   end
 end


### PR DESCRIPTION
@aturkewi 

Multiple students have asked questions about this and there's 2 issues filed already. It seems like a simple fix... The instructions say to create a migration to change the data type of this column to a string. But the tests are expecting it to be a boolean. Thus, following the instructions makes this test fail.

This fix brings the instructions and the specs into agreement.